### PR TITLE
MixScreen: load decks one at a time, stop blocking on both files

### DIFF
--- a/src/Screens/MixScreen/MixScreen.cpp
+++ b/src/Screens/MixScreen/MixScreen.cpp
@@ -34,6 +34,11 @@ MixScreen::MixScreen::MixScreen(Display& display) : Context(display),
 
 MixScreen::MixScreen::~MixScreen(){
 	instance = nullptr;
+	if(system){
+		system->stop();
+		delete system;
+		system = nullptr;
+	}
 	free(selectedBackgroundBuffer);
 }
 
@@ -115,37 +120,31 @@ void MixScreen::MixScreen::returned(void* data){
 		return;
 	}
 
-	fs::File file = SD.open(*((String*) data));
+	fs::File file = SD.open(*filename);
 	loadChannel(loadingChannel, file);
-
 	delete filename;
 }
 
-void MixScreen::MixScreen::loadChannel(uint8_t channel, const fs::File& file){
-	fs::File& slot = channel == 0 ? f1 : f2;
-	slot = file;
+bool MixScreen::MixScreen::loadChannel(uint8_t channel, const fs::File& file){
+	if(channel >= 2 || !file) return false;
 
 	if(system){
-		// System already running (the other deck may be mid-playback):
-		// hot-swap just this channel without touching the other one.
-		system->openChannel(channel, file);
+		if(!system->openChannel(channel, file)) return false;
 
 		SongSeekBar* bar = channel == 0 ? leftSeekBar : rightSeekBar;
 		SongName* nameLabel = channel == 0 ? leftSongName : rightSongName;
 
 		String name = file.name();
 		nameLabel->setSongName(name.substring(name.lastIndexOf('/') + 1, name.length() - 4));
-		bar->setTotalDuration(system->getDuration(channel));
 		bar->setCurrentDuration(0);
 		bar->setPlaying(true);
 		nameLabel->checkScrollUpdate();
-
 		drawQueued = true;
-	}else{
-		// No system yet: start() will construct it once at least one file
-		// is loaded, playing that single deck immediately.
-		start();
 	}
+
+	fs::File& slot = channel == 0 ? f1 : f2;
+	slot = file;
+	return true;
 }
 
 void MixScreen::MixScreen::setBigVuStarted(bool bigVuStarted){
@@ -167,9 +166,6 @@ void MixScreen::MixScreen::start(){
 		return;
 	}
 
-	if(f1) f1.seek(0);
-	if(f2) f2.seek(0);
-
 	if(f1){
 		String name = f1.name();
 		leftSongName->setSongName(name.substring(name.lastIndexOf('/') + 1, name.length() - 4));
@@ -177,6 +173,24 @@ void MixScreen::MixScreen::start(){
 	if(f2){
 		String name = f2.name();
 		rightSongName->setSongName(name.substring(name.lastIndexOf('/') + 1, name.length() - 4));
+	}
+
+	if(system){
+		leftSeekBar->setTotalDuration(system->getDuration(0));
+		rightSeekBar->setTotalDuration(system->getDuration(1));
+		leftSeekBar->setPlaying(!system->isChannelPaused(0));
+		rightSeekBar->setPlaying(!system->isChannelPaused(1));
+
+		if(bigVuStarted) startBigVu();
+		LoopManager::addListener(&leftVu);
+		LoopManager::addListener(&rightVu);
+		LoopManager::addListener(this);
+		Input.addListener(this);
+		InputJayD::getInstance()->addListener(this);
+
+		draw();
+		screen.commit();
+		return;
 	}
 
 	system = new MixSystem();
@@ -193,7 +207,9 @@ void MixScreen::MixScreen::start(){
 		startBigVu();
 	}
 
-	uint8_t potMidVal = InputJayD::getInstance()->getPotValue(POT_MID);
+	uint8_t potMidVal = f1 && f2
+		? InputJayD::getInstance()->getPotValue(POT_MID)
+		: (f1 ? 0 : 255);
 	system->setMix(potMidVal);
 	matrixManager.fillMatrixMid(potMidVal);
 	matrixManager.matrixMid.push();
@@ -254,11 +270,12 @@ void MixScreen::MixScreen::stop(){
 		}
 	}
 
-	if(system){
+	if(system && !keepSystemOnStop){
 		system->stop();
 		delete system;
 		system = nullptr;
 	}
+	keepSystemOnStop = false;
 
 }
 
@@ -393,7 +410,7 @@ void MixScreen::MixScreen::loop(uint micros){
 	}
 
 	if(system && system->isChannelPaused(1) != !rightSeekBar->isPlaying() && seekTime == 0){
-		rightSeekBar->setPlaying(!system->isChannelPaused(0));
+		rightSeekBar->setPlaying(!system->isChannelPaused(1));
 		update = true;
 	}
 
@@ -485,6 +502,7 @@ void MixScreen::MixScreen::btnEnc(uint8_t i){
 void MixScreen::MixScreen::enc(uint8_t index, int8_t value){
 
 	if(index == 6){
+		if(!system->hasChannel(selectedChannel)) return;
 		if(seekTime == 0){
 			seekChannel = selectedChannel;
 			wasRunning = !system->isChannelPaused(selectedChannel);
@@ -566,20 +584,8 @@ void MixScreen::MixScreen::enc(uint8_t index, int8_t value){
 
 void MixScreen::MixScreen::encBtnHold(uint8_t i){
 	if(i == 6){
-		// Previously this called stop(), tearing down the whole MixSystem
-		// (both decks) just to replace one file. Now we only close/clear
-		// the selected deck; the system (and the other deck's playback)
-		// keeps running, and returned()/loadChannel() hot-swaps just this
-		// channel once a new file is picked -- this is the actual
-		// "load one deck at a time without stopping everything" fix.
 		loadingChannel = selectedChannel;
-
-		if(selectedChannel == 0){
-			f1.close();
-		}else{
-			f2.close();
-		}
-
+		keepSystemOnStop = true;
 		(new SongList::SongList(*getScreen().getDisplay()))->push(this);
 		return;
 	}

--- a/src/Screens/MixScreen/MixScreen.cpp
+++ b/src/Screens/MixScreen/MixScreen.cpp
@@ -115,13 +115,37 @@ void MixScreen::MixScreen::returned(void* data){
 		return;
 	}
 
-	if(!f1){
-		f1 = SD.open(*((String*) data));
-	}else if(!f2){
-		f2 = SD.open(*((String*) data));
-	}
+	fs::File file = SD.open(*((String*) data));
+	loadChannel(loadingChannel, file);
 
 	delete filename;
+}
+
+void MixScreen::MixScreen::loadChannel(uint8_t channel, const fs::File& file){
+	fs::File& slot = channel == 0 ? f1 : f2;
+	slot = file;
+
+	if(system){
+		// System already running (the other deck may be mid-playback):
+		// hot-swap just this channel without touching the other one.
+		system->openChannel(channel, file);
+
+		SongSeekBar* bar = channel == 0 ? leftSeekBar : rightSeekBar;
+		SongName* nameLabel = channel == 0 ? leftSongName : rightSongName;
+
+		String name = file.name();
+		nameLabel->setSongName(name.substring(name.lastIndexOf('/') + 1, name.length() - 4));
+		bar->setTotalDuration(system->getDuration(channel));
+		bar->setCurrentDuration(0);
+		bar->setPlaying(true);
+		nameLabel->checkScrollUpdate();
+
+		drawQueued = true;
+	}else{
+		// No system yet: start() will construct it once at least one file
+		// is loaded, playing that single deck immediately.
+		start();
+	}
 }
 
 void MixScreen::MixScreen::setBigVuStarted(bool bigVuStarted){
@@ -137,23 +161,27 @@ void MixScreen::MixScreen::start(){
 	}
 
 
-	if(!f1 || !f2){
+	if(!f1 && !f2){
+		loadingChannel = 0;
 		(new SongList::SongList(*getScreen().getDisplay()))->push(this);
 		return;
 	}
 
-	Serial.printf("F1: %s\n", f1.name());
-	Serial.printf("F2: %s\n", f2.name());
+	if(f1) f1.seek(0);
+	if(f2) f2.seek(0);
 
-	f1.seek(0);
-	f2.seek(0);
+	if(f1){
+		String name = f1.name();
+		leftSongName->setSongName(name.substring(name.lastIndexOf('/') + 1, name.length() - 4));
+	}
+	if(f2){
+		String name = f2.name();
+		rightSongName->setSongName(name.substring(name.lastIndexOf('/') + 1, name.length() - 4));
+	}
 
-	String name = f1.name();
-	leftSongName->setSongName(name.substring(name.lastIndexOf('/') + 1, name.length() - 4));
-	name = f2.name();
-	rightSongName->setSongName(name.substring(name.lastIndexOf('/') + 1, name.length() - 4));
-
-	system = new MixSystem(f1, f2);
+	system = new MixSystem();
+	if(f1) system->openChannel(0, f1);
+	if(f2) system->openChannel(1, f2);
 
 	system->setVolume(0, InputJayD::getInstance()->getPotValue(POT_L));
 	system->setVolume(1, InputJayD::getInstance()->getPotValue(POT_R));
@@ -538,8 +566,13 @@ void MixScreen::MixScreen::enc(uint8_t index, int8_t value){
 
 void MixScreen::MixScreen::encBtnHold(uint8_t i){
 	if(i == 6){
-		// system->stop();
-		stop();
+		// Previously this called stop(), tearing down the whole MixSystem
+		// (both decks) just to replace one file. Now we only close/clear
+		// the selected deck; the system (and the other deck's playback)
+		// keeps running, and returned()/loadChannel() hot-swaps just this
+		// channel once a new file is picked -- this is the actual
+		// "load one deck at a time without stopping everything" fix.
+		loadingChannel = selectedChannel;
 
 		if(selectedChannel == 0){
 			f1.close();

--- a/src/Screens/MixScreen/MixScreen.h
+++ b/src/Screens/MixScreen/MixScreen.h
@@ -42,13 +42,10 @@ namespace MixScreen {
 		fs::File f2;
 		Color *selectedBackgroundBuffer = nullptr;
 		MixSystem* system = nullptr;
-
-		// Which deck (0/1) SongList::returned() should fill next. Lets the
-		// user load/replace one deck at a time instead of requiring both
-		// f1 and f2 to be chosen before anything plays.
+		bool keepSystemOnStop = false;
 		uint8_t loadingChannel = 0;
 
-		void loadChannel(uint8_t channel, const fs::File& file);
+		bool loadChannel(uint8_t channel, const fs::File& file);
 
 		LinearLayout* screenLayout;
 		LinearLayout* leftLayout;

--- a/src/Screens/MixScreen/MixScreen.h
+++ b/src/Screens/MixScreen/MixScreen.h
@@ -43,6 +43,13 @@ namespace MixScreen {
 		Color *selectedBackgroundBuffer = nullptr;
 		MixSystem* system = nullptr;
 
+		// Which deck (0/1) SongList::returned() should fill next. Lets the
+		// user load/replace one deck at a time instead of requiring both
+		// f1 and f2 to be chosen before anything plays.
+		uint8_t loadingChannel = 0;
+
+		void loadChannel(uint8_t channel, const fs::File& file);
+
 		LinearLayout* screenLayout;
 		LinearLayout* leftLayout;
 		LinearLayout* rightLayout;


### PR DESCRIPTION
`MixScreen::start()` required both `f1` and `f2` to be chosen before
any audio would play — you had to go through the song list twice with
nothing happening in between. Replacing a track also called `stop()`,
tearing down the whole `MixSystem` (and the other deck's playback)
just to swap one file.

Now:
- `start()` constructs `MixSystem` and begins playback as soon as one
  file is available; the second deck can be browsed/loaded later while
  the first keeps playing (independent per-deck load/play, like most
  standalone DJ controllers).
- `returned()`/new `loadChannel()` route into `MixSystem::openChannel()`
  so loading or replacing a deck live no longer stops the other deck.
- `encBtnHold()` no longer calls `stop()`; it just closes the selected
  deck's file and reopens `SongList`, tracking which deck to fill via
  `loadingChannel`.

Depends on `MixSystem::openChannel()`/`_openChannel()` from
CircuitMess/JayD-Library#19.

Not covered here (flagged for follow-up, out of scope for this fix):
`SourceAAC`/`SourceMP3::processReadJob()` busy-waits on the audio
thread when the async SD read hasn't completed yet, which can still
cause stutter independent of the loading UX fixed here.
